### PR TITLE
Add optional topic update loop for minecraft

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Settings can either be included as a part of the environment or in a .env file.
 - `SEABIRD_DISABLED_PLUGINS` - comma-separated list of plugins that should not be enabled
 - `DARKSKY_API_KEY` - needed for forecast/weather support
 - `GOOGLE_MAPS_API_KEY` - needed for forecast/weather support
+- `MINECRAFT_TOPIC_UPDATE_ENABLED` - allow the Minecraft plugin to update a channel's topic with server information
+- `MINECRAFT_TOPIC_UPDATE_HOSTPORT` - `hostname[:port]` for the Minecraft plugin topic updater to use
+- `MINECRAFT_TOPIC_UPDATE_CHANNEL` - `#some-channel` IRC channel for the Minecraft plugin topic updater to update
 
 ## Writing a new plugin
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Settings can either be included as a part of the environment or in a .env file.
 - `MINECRAFT_TOPIC_UPDATE_ENABLED` - allow the Minecraft plugin to update a channel's topic with server information
 - `MINECRAFT_TOPIC_UPDATE_HOSTPORT` - `hostname[:port]` for the Minecraft plugin topic updater to use
 - `MINECRAFT_TOPIC_UPDATE_CHANNEL` - `#some-channel` IRC channel for the Minecraft plugin topic updater to update
+- `MINECRAFT_TOPIC_UPDATE_INTERVAL_SECONDS` - The number of seconds in between each topic update. Defaults to 60 seconds.
 
 ## Writing a new plugin
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -8,6 +8,13 @@ pub enum Event<'a> {
     // 001 nick :welcome text
     RplWelcome(&'a str, &'a str),
 
+    // 332 nick #channel :topic
+    RplTopic {
+        nick: &'a str,
+        channel: &'a str,
+        topic: &'a str,
+    },
+
     // PRIVMSG somewhere :!command arg
     Command(&'a str, Option<&'a str>),
 
@@ -38,6 +45,11 @@ impl<'a> Event<'a> {
                 }
             }
             ("001", 2) => Event::RplWelcome(&msg.params[0][..], &msg.params[1][..]),
+            ("332", 3) => Event::RplTopic {
+                nick: &msg.params[0][..],
+                channel: &msg.params[1][..],
+                topic: &msg.params[2][..],
+            },
             _ => Event::Raw(
                 &msg.command[..],
                 msg.params.iter().map(|s| s.as_str()).collect(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ mod migrations;
 mod plugin;
 mod plugins;
 mod prelude;
-mod utils;
+pub(crate) mod utils;
 
 async fn check_err<T>(ctx: &client::Context, res: error::Result<T>) {
     if let Err(err) = res {

--- a/src/plugins/minecraft.rs
+++ b/src/plugins/minecraft.rs
@@ -1,8 +1,23 @@
+use std::time::Duration;
+
 use async_minecraft_ping::ConnectionConfig;
+use log::info;
+use tokio::time::timeout;
 
 use crate::prelude::*;
 
-pub struct MinecraftPlugin;
+enum TopicUpdateConfig {
+    NoUpdate,
+    Update {
+        server_hostname: String,
+        server_port: u16,
+        channel: String,
+    },
+}
+
+pub struct MinecraftPlugin {
+    update_config: TopicUpdateConfig,
+}
 
 impl MinecraftPlugin {
     async fn handle_mc_players(&self, ctx: &Context, arg: &str) -> Result<()> {
@@ -30,22 +45,79 @@ impl MinecraftPlugin {
 
         Ok(())
     }
+
+    async fn update_topic(&self) -> Result<()> {
+        if let TopicUpdateConfig::Update { ref server_hostname, server_port, ref channel } = self.update_config {
+            let config = ConnectionConfig::build(server_hostname.to_string()).with_port(server_port);
+            let mut connection = config.connect().await?;
+
+            let status = connection.status().await?;
+
+            let topic = format!("{}:{} - {} of {} player(s) online. \"{}\"",
+                server_hostname, server_port, status.players.online, status.players.max,
+                status.description.text,
+            );
+
+            // TODO(jsvana): set topic here: TOPIC #chan TOPIC
+            info!("Would set topic on {} to \"{}\"", channel, topic);
+        }
+
+        Ok(())
+    }
 }
 
 #[async_trait]
 impl Plugin for MinecraftPlugin {
     fn new_from_env() -> Result<Self> {
-        Ok(MinecraftPlugin {})
+        let updates_enabled = dotenv::var("MINECRAFT_TOPIC_UPDATE_ENABLED").unwrap_or_else(|_| "false".to_string()).parse().map_err(|_| {
+            anyhow::format_err!("$MINECRAFT_TOPIC_UPDATE_ENABLED is not a valid boolean. Error from the \"minecraft\" plugin.")
+        })?;
+        let update_config = if updates_enabled {
+            TopicUpdateConfig::Update {
+                server_hostname: dotenv::var("MINECRAFT_TOPIC_UPDATE_SERVER_HOSTNAME").map_err(|_| {
+                    anyhow::format_err!(
+                        "Missing $MINECRAFT_TOPIC_UPDATE_SERVER_HOSTNAME. Required by the \"minecraft\" plugin because MINECRAFT_TOPIC_UPDATE_ENABLED was set to true."
+                    )
+                })?,
+                server_port: dotenv::var("MINECRAFT_TOPIC_UPDATE_SERVER_PORT").unwrap_or_else(|_| "25565".to_string()).parse().map_err(|_| {
+                    anyhow::format_err!(
+                        "$MINECRAFT_TOPIC_UPDATE_PORT is an invalid u16. Required by the \"minecraft\" plugin because MINECRAFT_TOPIC_UPDATE_ENABLED was set to true."
+                    )
+                })?,
+                channel: dotenv::var("MINECRAFT_TOPIC_UPDATE_CHANNEL").map_err(|_| {
+                    anyhow::format_err!(
+                        "Missing $MINECRAFT_TOPIC_UPDATE_CHANNEL. Required by the \"minecraft\" plugin because MINECRAFT_TOPIC_UPDATE_ENABLED was set to true."
+                    )
+                })?,
+            }
+        } else {
+            TopicUpdateConfig::NoUpdate
+        };
+
+        Ok(MinecraftPlugin {
+            update_config,
+        })
     }
 
+<<<<<<< HEAD
     async fn run(self, _bot: Arc<Client>, mut stream: Receiver<Arc<Context>>) -> Result<()> {
-        while let Some(ctx) = stream.next().await {
-            let res = match ctx.as_event() {
-                Event::Command("mc_players", Some(arg)) => self.handle_mc_players(&ctx, arg).await,
-                _ => Ok(()),
-            };
+        // TODO(jsvana): make this update loop update the topic at regular intervals
+        // instead of what it's doing now.
+        loop {
+            match timeout(Duration::from_secs(60), stream.next()).await {
+                Ok(res) => match res {
+                    Some(ctx) => {
+                        let res = match ctx.as_event() {
+                            Event::Command("mc_players", Some(arg)) => self.handle_mc_players(&ctx, arg).await,
+                            _ => Ok(()),
+                        };
 
-            crate::check_err(&ctx, res).await;
+                        crate::check_err(&ctx, res).await;
+                    },
+                    None => break,
+                }
+                Err(_) => self.update_topic().await?,
+            }
         }
 
         Err(format_err!("minecraft plugin exited early"))

--- a/src/plugins/minecraft.rs
+++ b/src/plugins/minecraft.rs
@@ -1,8 +1,7 @@
 use std::time::Duration;
 
-use anyhow::Context as AnyhowContext;
 use async_minecraft_ping::ConnectionConfig;
-use futures::future::{select, Either};
+use futures::future::try_join;
 use tokio::time::interval;
 
 use crate::prelude::*;
@@ -19,33 +18,13 @@ enum TopicUpdateConfig {
     },
 }
 
-struct HostPort {
-    host: String,
-    port: u16,
-}
-
 pub struct MinecraftPlugin {
     update_config: TopicUpdateConfig,
 }
 
-fn split_host_port(hostport: &str, default_port: &str) -> Result<HostPort> {
-    let parts: Vec<&str> = hostport.splitn(2, ':').collect();
-    let host = parts
-        .get(0)
-        .map(|s| (*s).to_string())
-        .ok_or_else(|| format_err!("missing hostport string (this should be impossible)"))?;
-    let port = parts
-        .get(1)
-        .unwrap_or_else(|| &default_port)
-        .parse()
-        .with_context(|| "hostport string has invalid port specifier")?;
-
-    Ok(HostPort { host, port })
-}
-
 impl MinecraftPlugin {
     async fn handle_mc_players(&self, ctx: &Context, arg: &str) -> Result<()> {
-        let host_port = split_host_port(arg, DEFAULT_PORT)?;
+        let host_port = utils::split_host_port(arg, DEFAULT_PORT)?;
 
         let config = ConnectionConfig::build(host_port.host).with_port(host_port.port);
         let mut connection = config.connect().await?;
@@ -62,16 +41,19 @@ impl MinecraftPlugin {
     }
 
     async fn query_topic(&self, bot: &Arc<Client>) -> Result<()> {
-        if let TopicUpdateConfig::Update {
-            ref channel, ..
-        } = self.update_config {
+        if let TopicUpdateConfig::Update { ref channel, .. } = self.update_config {
             bot.send("TOPIC", vec![channel]).await?;
         }
 
         Ok(())
     }
 
-    async fn update_topic(&self, bot: &Arc<Client>, incoming_channel: &str, last_topic: &str) -> Result<()> {
+    async fn update_topic(
+        &self,
+        bot: &Arc<Client>,
+        incoming_channel: &str,
+        last_topic: &str,
+    ) -> Result<()> {
         if let TopicUpdateConfig::Update {
             ref server_hostname,
             server_port,
@@ -107,52 +89,43 @@ impl MinecraftPlugin {
         Ok(())
     }
 
-    async fn handle_message(&self, bot: &Arc<Client>, context: Arc<Context>) {
-        let res = match context.as_event() {
-            Event::Command("mc_players", Some(arg)) => {
-                self.handle_mc_players(&context, arg).await
-            }
-            Event::RplTopic {
-                nick: _,
-                channel,
-                topic,
-            } => {
-                self.update_topic(&bot, channel, topic).await
-            }
-            _ => Ok(()),
-        };
-
-        crate::check_err(&context, res).await;
-    }
-
-    async fn run_update_loop(&self, bot: Arc<Client>, mut stream: Receiver<Arc<Context>>) -> Result<()> {
-        if let TopicUpdateConfig::Update { update_interval, .. } = self.update_config {
+    async fn run_update_loop(&self, bot: Arc<Client>) -> Result<()> {
+        if let TopicUpdateConfig::Update {
+            update_interval, ..
+        } = self.update_config
+        {
             let mut timer = interval(update_interval);
 
-            loop {
-                let next = select(stream.next(), timer.next()).await;
-
-                match next {
-                    Either::Left((Some(context), _)) => {
-                        self.handle_message(&bot, context).await;
-                    }
-                    Either::Right(_) => {
-                        self.query_topic(&bot).await?;
-                    }
-                    _ => {}
-                }
+            while let Some(_) = timer.next().await {
+                self.query_topic(&bot).await?;
             }
         }
 
-        Ok(())
+        Err(format_err!("minecraft update_loop exited early"))
     }
 
-    async fn run_only_read_commands(&self, bot: Arc<Client>, mut stream: Receiver<Arc<Context>>) -> Result<()> {
+    async fn run_event_loop(
+        &self,
+        bot: Arc<Client>,
+        mut stream: Receiver<Arc<Context>>,
+    ) -> Result<()> {
         while let Some(context) = stream.next().await {
-            self.handle_message(&bot, context).await;
+            let res = match context.as_event() {
+                Event::Command("mc_players", Some(arg)) => {
+                    self.handle_mc_players(&context, arg).await
+                }
+                Event::RplTopic {
+                    nick: _,
+                    channel,
+                    topic,
+                } => self.update_topic(&bot, channel, topic).await,
+                _ => Ok(()),
+            };
+
+            crate::check_err(&context, res).await;
         }
 
-        Err(format_err!("karma plugin exited early"))
+        Err(format_err!("minecraft event_loop exited early"))
     }
 }
 
@@ -167,7 +140,7 @@ impl Plugin for MinecraftPlugin {
                 "Missing $MINECRAFT_TOPIC_UPDATE_SERVER_HOSTPORT. Required by the \"minecraft\" plugin because $MINECRAFT_TOPIC_UPDATE_ENABLED was set to true.".to_string()
             })?;
 
-            let hostport = split_host_port(&server_hostport, DEFAULT_PORT).with_context(|| {
+            let hostport = utils::split_host_port(&server_hostport, DEFAULT_PORT).with_context(|| {
                 "$MINECRAFT_TOPIC_UPDATE_SERVER_HOSTPORT is invalid. Required by the \"minecraft\" plugin because $MINECRAFT_TOPIC_UPDATE_ENABLED was set to true.".to_string()
             })?;
 
@@ -175,10 +148,9 @@ impl Plugin for MinecraftPlugin {
                 "Missing $MINECRAFT_TOPIC_UPDATE_CHANNEL. Required by the \"minecraft\" plugin because MINECRAFT_TOPIC_UPDATE_ENABLED was set to true.".to_string()
             })?;
 
-            let update_interval_seconds = dotenv::var("MINECRAFT_TOPIC_UPDATE_INTERVAL_SECONDS").unwrap_or_else(|_| "60".to_string()).parse::<u64>().with_context(|| {
+            let update_interval = dotenv::var("MINECRAFT_TOPIC_UPDATE_INTERVAL_SECONDS").unwrap_or_else(|_| "60".to_string()).parse::<u64>().with_context(|| {
                 "$MINECRAFT_TOPIC_UPDATE_INTERVAL_SECONDS has invalid duration. Required by the \"minecraft\" plugin because MINECRAFT_TOPIC_UPDATE_ENABLED was set to true.".to_string()
-            })?;
-            let update_interval = Duration::from_secs(update_interval_seconds);
+            }).map(Duration::from_secs)?;
 
             TopicUpdateConfig::Update {
                 server_hostname: hostport.host,
@@ -190,18 +162,21 @@ impl Plugin for MinecraftPlugin {
             TopicUpdateConfig::NoUpdate
         };
 
-        Ok(MinecraftPlugin {
-            update_config,
-        })
+        Ok(MinecraftPlugin { update_config })
     }
 
     async fn run(self, bot: Arc<Client>, stream: Receiver<Arc<Context>>) -> Result<()> {
         // Only run the update loop if we actually want to update the topic
         match self.update_config {
-            TopicUpdateConfig::Update { .. } => self.run_update_loop(bot, stream).await,
-            TopicUpdateConfig::NoUpdate => {
-                self.run_only_read_commands(bot, stream).await
+            TopicUpdateConfig::Update { .. } => {
+                try_join(
+                    self.run_event_loop(bot.clone(), stream),
+                    self.run_update_loop(bot),
+                )
+                .await?;
+                Ok(())
             }
+            TopicUpdateConfig::NoUpdate => self.run_event_loop(bot, stream).await,
         }
     }
 }

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -1,6 +1,6 @@
 pub use std::sync::Arc;
 
-pub use anyhow::format_err;
+pub use anyhow::{format_err, Context as AnyhowContext};
 pub use async_trait::async_trait;
 pub use itertools::Itertools;
 pub use tokio::stream::{Stream, StreamExt};
@@ -13,3 +13,4 @@ pub use crate::client::{Client, ClientConfig, ClientState, Context};
 pub use crate::error::Result;
 pub use crate::event::Event;
 pub use crate::plugin::Plugin;
+pub(crate) use crate::utils;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,3 +14,23 @@ pub fn to_sentence_case(s: &str) -> String {
     cap.push_str(graphemes.as_str());
     cap
 }
+
+pub struct HostPort {
+    pub host: String,
+    pub port: u16,
+}
+
+pub fn split_host_port(hostport: &str, default_port: &str) -> Result<HostPort> {
+    let parts: Vec<&str> = hostport.splitn(2, ':').collect();
+    let host = parts
+        .get(0)
+        .map(|s| (*s).to_string())
+        .ok_or_else(|| format_err!("missing hostport string (this should be impossible)"))?;
+    let port = parts
+        .get(1)
+        .unwrap_or_else(|| &default_port)
+        .parse()
+        .with_context(|| "hostport string has invalid port specifier")?;
+
+    Ok(HostPort { host, port })
+}


### PR DESCRIPTION
This is currently inop. The plugin structure doesn't provide plugins
with a way to send messages outside of receiving the bot context from
the message stream. It's possible that we could store a reference
in the plugin to the first instance of that context, but that's
pretty gnarly.

Any ideas? Does this seem reasonable outside of the `TODO`s and
the above issue?